### PR TITLE
第２章　面接官が面談日程を承認 or 拒否するための機能

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,6 @@
 class InterviewsController < ApplicationController
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
-  before_action :set_user,      only: [:index, :new, :edit, :create, :update, :destroy]
+  before_action :set_user,      only: [:index, :show, :new, :edit, :create, :update, :destroy]
   before_action :correct_user,  only: [:new, :edit, :create, :destroy]
 
   # GET /interviews
@@ -30,7 +30,7 @@ class InterviewsController < ApplicationController
 
     respond_to do |format|
       if @interview.save
-        format.html { redirect_to user_interviews_path(current_user), notice: 'Interview was successfully created.' }
+        format.html { redirect_to user_interviews_path(@user), notice: 'Interview was successfully created.' }
         format.json { render :show, status: :created, location: @interview }
       else
         format.html { render :new }
@@ -44,7 +44,7 @@ class InterviewsController < ApplicationController
   def update
     respond_to do |format|
       if @interview.update(interview_params)
-        format.html { redirect_to user_interviews_path(current_user), notice: 'Interview was successfully updated.' }
+        format.html { redirect_to user_interviews_path(@user), notice: 'Interview was successfully updated.' }
         format.json { render :show, status: :ok, location: @interview }
       else
         format.html { render :edit }
@@ -58,12 +58,13 @@ class InterviewsController < ApplicationController
   def destroy
     @interview.destroy
     respond_to do |format|
-      format.html { redirect_to user_interviews_url, notice: 'Interview was successfully destroyed.' }
+      format.html { redirect_to user_interviews_url(@user), notice: 'Interview was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
 
   private
+
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
       @interview = Interview.find(params[:id])

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -7,6 +7,7 @@ class InterviewsController < ApplicationController
   # GET /interviews.json
   def index
     @interviews = Interview.where(user_id: params[:user_id])
+    @scheduled_interview = Interview.find_by(approval: 1 )
   end
 
   # GET /interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,8 +6,8 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @scheduled_interview = Interview.find_by(approval: 1 )
     @interviews = Interview.where(user_id: params[:user_id]).order(:date)
+    @scheduled_interview = @interviews.find_by(approval: 1 )
   end
 
   # GET /interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -48,8 +48,15 @@ class InterviewsController < ApplicationController
         format.html { redirect_to user_interviews_path(@user), notice: 'Interview was successfully updated.' }
         format.json { render :show, status: :ok, location: @interview }
       else
-        format.html { render :edit }
-        format.json { render json: @interview.errors, status: :unprocessable_entity }
+        if @user.id == current_user.id
+          format.html { render :edit }
+          format.json { render json: @interview.errors, status: :unprocessable_entity }
+        else
+          format.html {
+            redirect_to user_interviews_path(@user),
+            notice: "The schedule can't be edited because it has already been approved or rejected."
+          }
+        end
       end
     end
   end
@@ -57,10 +64,16 @@ class InterviewsController < ApplicationController
   # DELETE /interviews/1
   # DELETE /interviews/1.json
   def destroy
-    @interview.destroy
     respond_to do |format|
-      format.html { redirect_to user_interviews_url(@user), notice: 'Interview was successfully destroyed.' }
-      format.json { head :no_content }
+      if @interview.destroy
+        format.html { redirect_to user_interviews_url(@user), notice: 'Interview was successfully destroyed.' }
+        format.json { head :no_content }
+      else
+        format.html {
+          redirect_to user_interviews_path(@user),
+          notice: "The schedule can't be edited because it has already been approved or rejected."
+        }
+      end
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,7 @@
 class InterviewsController < ApplicationController
   before_action :set_interview, only: [:show, :edit, :update, :destroy]
-  before_action :correct_user,  only: [:new, :edit, :create, :update, :destroy]
+  before_action :set_user,      only: [:index, :new, :edit, :create, :update, :destroy]
+  before_action :correct_user,  only: [:new, :edit, :create, :destroy]
 
   # GET /interviews
   # GET /interviews.json
@@ -73,10 +74,13 @@ class InterviewsController < ApplicationController
       params.require(:interview).permit(:date, :approval)
     end
 
-    def correct_user
+    def set_user
       @user = User.find(params[:user_id])
+    end
+
+    def correct_user
       unless @user.id == current_user.id
-        redirect_to(user_interviews_url)
+        redirect_to(user_interviews_url(@user))
         flash[:notice] = "You can't edit and delete it."
       end
     end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -32,10 +32,8 @@ class InterviewsController < ApplicationController
     respond_to do |format|
       if @interview.save
         format.html { redirect_to user_interviews_path(@user), notice: 'Interview was successfully created.' }
-        format.json { render :show, status: :created, location: @interview }
       else
         format.html { render :new }
-        format.json { render json: @interview.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -46,11 +44,9 @@ class InterviewsController < ApplicationController
     respond_to do |format|
       if @interview.update(interview_params)
         format.html { redirect_to user_interviews_path(@user), notice: 'Interview was successfully updated.' }
-        format.json { render :show, status: :ok, location: @interview }
       else
         if @user.id == current_user.id
           format.html { render :edit }
-          format.json { render json: @interview.errors, status: :unprocessable_entity }
         else
           format.html {
             redirect_to user_interviews_path(@user),
@@ -66,8 +62,10 @@ class InterviewsController < ApplicationController
   def destroy
     respond_to do |format|
       if @interview.destroy
-        format.html { redirect_to user_interviews_url(@user), notice: 'Interview was successfully destroyed.' }
-        format.json { head :no_content }
+        format.html {
+          redirect_to user_interviews_path(@user),
+          notice: 'Interview was successfully destroyed.'
+        }
       else
         format.html {
           redirect_to user_interviews_path(@user),

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,8 +6,8 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @interviews = Interview.where(user_id: params[:user_id])
     @scheduled_interview = Interview.find_by(approval: 1 )
+    @interviews = Interview.where(user_id: params[:user_id]).order(:date)
   end
 
   # GET /interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,7 +4,7 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @interviews = Interview.where(user_id: current_user.id)
+    @interviews = Interview.where(user_id: params[:user_id])
   end
 
   # GET /interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,7 +4,7 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @interviews = Interview.all
+    @interviews = Interview.where(user_id: current_user.id)
   end
 
   # GET /interviews/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def index
+    @users = User.where.not(id: current_user.id)
   end
 
   def show

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,8 +1,15 @@
 class Interview < ApplicationRecord
+  validate :date_cannot_be_in_the_past
   belongs_to :user
   enum approval: { pending: 0, approve: 1, reject: 2 }
   after_update :reject_other_interviews
 
+  def date_cannot_be_in_the_past
+    if self.date.present? && self.date < Date.today
+      errors.add(:date, "can't be in the past")
+    end
+  end
+  
   private
     def reject_other_interviews
       if self.approval == 'approve'

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,7 +1,9 @@
 class Interview < ApplicationRecord
   validate :date_cannot_be_in_the_past
+  validate :cannot_edit_schedule_that_was_approved_or_rejected
   belongs_to :user
   enum approval: { pending: 0, approve: 1, reject: 2 }
+  before_destroy :cannot_edit_schedule_that_was_approved_or_rejected
   after_update :reject_other_interviews
 
   def date_cannot_be_in_the_past
@@ -9,7 +11,14 @@ class Interview < ApplicationRecord
       errors.add(:date, "can't be in the past")
     end
   end
-  
+
+  def cannot_edit_schedule_that_was_approved_or_rejected
+    if Interview.find_by(id: self.id)&.approval.in?(['approve','reject'])
+      errors[:base] << "The schedule can't be edited because it has already been approved or rejected"
+      throw :abort
+    end
+  end
+
   private
     def reject_other_interviews
       if self.approval == 'approve'

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,12 @@
 class Interview < ApplicationRecord
   belongs_to :user
   enum approval: { pending: 0, approve: 1, reject: 2 }
+  after_update :reject_other_interviews
+
+  private
+    def reject_other_interviews
+      if self.approval == 'approve'
+        Interview.where('user_id = ? AND NOT (id = ?)', self.user_id, self.id).update_all(approval: 'reject')
+      end
+    end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,4 @@
 class Interview < ApplicationRecord
   belongs_to :user
+  enum approval: { pending: 0, approve: 1, reject: 2 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-
   enum gender: { male: 0, female: 1 }
-
   has_many :interviews
+
+  def age
+    date_format = "%Y%m%d"
+    (Date.today.strftime(date_format).to_i - self.birthday&.strftime(date_format).to_i) / 10000 if self.birthday
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,6 +7,7 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
   <%= f.text_field :name, autocomplete: "off" %>
+  <%= f.select :gender, User.genders.keys.to_a, {} %>
   <%= f.date_field :birthday, autocomplete: "off" %>
   <%= f.text_field :school, autocomplete: "off" %>
   <%= f.password_field :password, autocomplete: "off" %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -16,11 +16,6 @@
     <%= form.datetime_select :date, id: :interview_date %>
   </div>
 
-  <div class="field">
-    <%= form.label :approval %>
-    <%= form.number_field :approval, id: :interview_approval %>
-  </div>
-
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [ :user, @interview ], local: true) do |form| %>
+<%= form_with(model: [ current_user, interview ], local: true) do |form| %>
   <% if interview.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(interview.errors.count, "error") %> prohibited this interview from being saved:</h2>

--- a/app/views/interviews/_other_interviews.html.erb
+++ b/app/views/interviews/_other_interviews.html.erb
@@ -22,3 +22,4 @@
 </table>
 
 <br>
+<%= link_to 'Back', users_path %>

--- a/app/views/interviews/_other_interviews.html.erb
+++ b/app/views/interviews/_other_interviews.html.erb
@@ -12,9 +12,9 @@
       <tr>
         <td><%= interview.date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', user_interview_path(interview.user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(interview.user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(interview.user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -22,4 +22,4 @@
 
 <br>
 
-<%= link_to 'New Interview', new_user_interview_path(current_user) %>
+<%= link_to 'New Interview', new_user_interview_path %>

--- a/app/views/interviews/_other_interviews.html.erb
+++ b/app/views/interviews/_other_interviews.html.erb
@@ -1,0 +1,25 @@
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Approval</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% interviews.each do |interview| %>
+      <tr>
+        <td><%= interview.date %></td>
+        <td><%= interview.approval %></td>
+        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Interview', new_user_interview_path(current_user) %>

--- a/app/views/interviews/_other_interviews.html.erb
+++ b/app/views/interviews/_other_interviews.html.erb
@@ -1,9 +1,12 @@
+<h2>Scheduled interview date</h2>
+<p><%= scheduled_interview&.date || "Undecided" %></p>
+
 <table>
   <thead>
     <tr>
       <th>Date</th>
       <th>Approval</th>
-      <th colspan="3"></th>
+      <th></th>
     </tr>
   </thead>
 
@@ -12,14 +15,10 @@
       <tr>
         <td><%= interview.date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(interview.user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(interview.user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(interview.user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <th><%= button_to 'Approve', user_interview_path(user, interview), method: :patch, params: { interview: {  approval: 'approve' } }, data: { confirm: 'Are you sure?' } %></th>
       </tr>
     <% end %>
   </tbody>
 </table>
 
 <br>
-
-<%= link_to 'New Interview', new_user_interview_path %>

--- a/app/views/interviews/_own_interviews.html.erb
+++ b/app/views/interviews/_own_interviews.html.erb
@@ -12,9 +12,9 @@
       <tr>
         <td><%= interview.date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/interviews/_own_interviews.html.erb
+++ b/app/views/interviews/_own_interviews.html.erb
@@ -12,9 +12,9 @@
       <tr>
         <td><%= interview.date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', user_interview_path(interview.user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(interview.user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(interview.user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/interviews/_own_interviews.html.erb
+++ b/app/views/interviews/_own_interviews.html.erb
@@ -12,9 +12,9 @@
       <tr>
         <td><%= interview.date %></td>
         <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(interview.user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(interview.user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(interview.user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', user_interview_path(user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/interviews/_own_interviews.html.erb
+++ b/app/views/interviews/_own_interviews.html.erb
@@ -1,0 +1,25 @@
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Approval</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% interviews.each do |interview| %>
+      <tr>
+        <td><%= interview.date %></td>
+        <td><%= interview.approval %></td>
+        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
+        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Interview', new_user_interview_path(current_user) %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to 'Show', user_interview_path(@interview.user, @interview) %> |
-<%= link_to 'Back', user_interviews_path(@interview.user) %>
+<%= link_to 'Show', user_interview_path(@user, @interview) %> |
+<%= link_to 'Back', user_interviews_path(@user) %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to 'Show', user_interview_path(current_user, @interview) %> |
-<%= link_to 'Back', user_interviews_path(current_user) %>
+<%= link_to 'Show', user_interview_path(@interview.user, @interview) %> |
+<%= link_to 'Back', user_interviews_path(@interview.user) %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,8 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <h1><%= @user.name %>'s Interviews</h1>
-<% if current_user.id.to_s == params[:user_id] %>
-  <%= render partial: "own_interviews", locals: {user: @user, interviews: @interviews} %>
+<% if current_user == @user %>
+  <%= render partial: "own_interviews", locals: {interviews: @interviews} %>
 <% else %>
   <%= render partial: "other_interviews", locals: {user: @user, interviews: @interviews, scheduled_interview: @scheduled_interview} %>
 <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,8 +1,8 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Interviews</h1>
+<h1><%= @user.name %>'s Interviews</h1>
 <% if current_user.id.to_s == params[:user_id] %>
-  <%= render partial: "own_interviews", locals: {interviews: @interviews} %>
+  <%= render partial: "own_interviews", locals: {user: @user, interviews: @interviews} %>
 <% else %>
-  <%= render partial: "other_interviews", locals: {interviews: @interviews} %>
+  <%= render partial: "other_interviews", locals: {user: @user, interviews: @interviews, scheduled_interview: @scheduled_interview} %>
 <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,29 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Interviews</h1>
-
-<table>
-  <thead>
-    <tr>
-      <th>Date</th>
-      <th>Approval</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @interviews.each do |interview| %>
-      <tr>
-        <td><%= interview.date %></td>
-        <td><%= interview.approval %></td>
-        <td><%= link_to 'Show', user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Edit', edit_user_interview_path(current_user, interview) %></td>
-        <td><%= link_to 'Destroy', user_interview_path(current_user, interview), method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<br>
-
-<%= link_to 'New Interview', new_user_interview_path(current_user) %>
+<% if current_user.id.to_s == params[:user_id] %>
+  <%= render partial: "own_interviews", locals: {interviews: @interviews} %>
+<% else %>
+  <%= render partial: "other_interviews", locals: {interviews: @interviews} %>
+<% end %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -10,5 +10,5 @@
   <%= @interview.approval %>
 </p>
 
-<%= link_to 'Edit', edit_user_interview_path(@interview.user, @interview) %> |
-<%= link_to 'Back', user_interviews_path(@interview.user) %>
+<%= link_to 'Edit', edit_user_interview_path(@user, @interview) %> |
+<%= link_to 'Back', user_interviews_path(@user) %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -10,5 +10,5 @@
   <%= @interview.approval %>
 </p>
 
-<%= link_to 'Edit', edit_user_interview_path(@interview) %> |
-<%= link_to 'Back', user_interviews_path %>
+<%= link_to 'Edit', edit_user_interview_path(@interview.user, @interview) %> |
+<%= link_to 'Back', user_interviews_path(@interview.user) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
       <header>
         <nav>
           <% if user_signed_in? %>
-            <strong><%= link_to current_user.name, users_path %></strong>
+            <strong><%= link_to 'e-Navigator', authenticated_root_path %></strong>
             <%= link_to 'Profile', edit_user_registration_path %>
             <%= link_to 'Interview', user_interviews_path(current_user) %>
             <%= link_to 'Logout', destroy_user_session_path, method: :delete %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
       <tr>
         <td><%= user.name %></td>
         <td><%= user.email %></td>
-        <td><%= user.birthday %></td>
+        <td><%= user.age %></td>
         <td><%= user.gender %></td>
         <td><%= user.school %></td>
         <td><%= user.interviews.find_by(approval: 'approve')&.date  || 'Undecided' %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,32 @@
 <p class="notice"><%= notice %></p>
 <h1>Users#index</h1>
 <p>Find me in app/views/users/index.html.erb</p>
+
+<h1>Users</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Age</th>
+      <th>Gender</th>
+      <th>school</th>
+      <th>Interview Datetime</th>
+      <th colspan="7"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td><%= user.email %></td>
+        <td><%= user.birthday %></td>
+        <td><%= user.gender %></td>
+        <td><%= user.school %></td>
+        <td><%= user.interviews.first %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,7 @@
         <td><%= user.birthday %></td>
         <td><%= user.gender %></td>
         <td><%= user.school %></td>
-        <td><%= user.interviews[0].date  if user.interviews[0]%></td>
+        <td><%= user.interviews.find_by(approval: 'approve')&.date  || 'Undecided' %></td>
         <th><%= link_to 'List', user_interviews_path(user) %></th>
       </tr>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,7 +13,7 @@
       <th>Gender</th>
       <th>school</th>
       <th>Interview Datetime</th>
-      <th colspan="7"></th>
+      <th></th>
     </tr>
   </thead>
 
@@ -25,7 +25,8 @@
         <td><%= user.birthday %></td>
         <td><%= user.gender %></td>
         <td><%= user.school %></td>
-        <td><%= user.interviews.first %></td>
+        <td><%= user.interviews[0].date  if user.interviews[0]%></td>
+        <th><%= link_to 'List', user_interviews_path(user) %></th>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,4 @@
 <p class="notice"><%= notice %></p>
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
 
 <h1>Users</h1>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,7 +24,7 @@
         <td><%= user.gender %></td>
         <td><%= user.school %></td>
         <td><%= user.interviews.find_by(approval: 'approve')&.date  || 'Undecided' %></td>
-        <th><%= link_to 'List', user_interviews_path(user) %></th>
+        <th><%= link_to 'Interviews list', user_interviews_path(user) %></th>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   devise_scope :user do
     authenticated :user do
-      root 'users#show', as: :authenticated_root
+      root 'users#index', as: :authenticated_root
     end
     unauthenticated do
       root 'devise/sessions#new', as: :unauthenticated_root

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
-  root 'users#index'
   devise_for :users
+  devise_scope :user do
+    authenticated :user do
+      root 'users#show', as: :authenticated_root
+    end
+    unauthenticated do
+      root 'devise/sessions#new', as: :unauthenticated_root
+    end
+  end
   resources :users
   resources :users do
     resources :interviews

--- a/db/migrate/20180408094846_change_column_default_to_interview.rb
+++ b/db/migrate/20180408094846_change_column_default_to_interview.rb
@@ -1,0 +1,8 @@
+class ChangeColumnDefaultToInterview < ActiveRecord::Migration[5.1]
+  def up
+    change_column_default :interviews, :approval, 0
+  end
+  def down
+    change_column_default :interviews, :approval, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180328074754) do
+ActiveRecord::Schema.define(version: 20180408094846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "interviews", force: :cascade do |t|
     t.datetime "date"
-    t.integer "approval"
+    t.integer "approval", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"


### PR DESCRIPTION
やりたかったこと
---

- 自分以外のユーザーの一覧をトップページに表示する
- 面接官用の面接日程一覧ページを作る
- 面談日程を承認or拒否できるようにする

やったこと
----

- 自分以外のユーザーの一覧をトップページに表示する
- 誕生日から年齢を算出する関数の作成
- パーシャルで`InterviewsController#index`の表示切替
- 面談日程を承認or拒否できるようにする
- 面談日程を承認した時、他の日程は"拒否”にする
- 今日以前の面談日程は承認できないようにする
- 承認した面談日程をトップページ及び各ユーザーのインタビュー一覧上部に表示


動作確認方法
---

- [ ] トップページに自分以外のユーザーが表示されているか
- [ ] トップページに自分以外のユーザーの年齢が表示されているか
- [ ] トップページから他のユーザーのインタビュー一覧へ飛び、表示を確認
- [ ] 面談日程が承認できるか
- [ ] 面談日程を承認した時、他の日程は"拒否”になっているか
- [ ] 今日以前の面談日程が承認・編集できないか
- [ ] 承認した面談日程がトップページ及び各ユーザーのインタビュー一覧上部に表示されているか

その他
---

- `InterviewsController`の`before_action`が３つあって、なんだかごちゃついているように感じるのですが、何かアドバイスなどあったりしますか？
- ちょっと今更感があるのですが、gitのブランチを`e-navigator-app`に集約してプルリクを出す形にしました！今までブランチが乱立して、文字通り大量に枝分かれしていたので少しはスッキリさせられるような気がします！
